### PR TITLE
fix(deps): mysqlclient from 2.0.2 to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ httplib2==0.18.1
 idna==2.10
 IPy==1.01
 lxml==4.6.2
-mysqlclient==2.0.2
+mysqlclient==2.0.1
 oauth2==1.9.0.post1
 oauthlib==3.1.0
 packaging==20.8


### PR DESCRIPTION
https://stackoverflow.com/questions/65281847/cant-install-mysqlclient-in-centos-7