### PR TITLE
.github/workflows: use deploy-cloudrun@v1

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -120,7 +120,7 @@ jobs:
           docker push ${{ env.IMAGE_CMD_EXPORT2CSV }}
 
       - name: Deploy to Cloud Run
-        uses: google-github-actions/deploy-cloudrun@main
+        uses: google-github-actions/deploy-cloudrun@v1
         with:
           service: ${{ env.SERVICE }}
           image: ${{ env.IMAGE_APP }}


### PR DESCRIPTION
```
Warning: google-github-actions/deploy-cloudrun is pinned at "main". We strongly advise against pinning to "@main" as it may be unstable. Please update your GitHub Action YAML from:

    uses: 'google-github-actions/deploy-cloudrun@main'

to:

    uses: 'google-github-actions/deploy-cloudrun@v1'
```