### PR TITLE
terraform: adjust memory limits of app

### DIFF
--- a/terraform/production/google_cloud_run_service.tf
+++ b/terraform/production/google_cloud_run_service.tf
@@ -10,7 +10,7 @@ resource "google_cloud_run_service" "app" {
         image = "asia-northeast1-docker.pkg.dev/srandom/app/app"
 
         resources {
-          limits = { "memory" : "512Mi", "cpu" : "1000m" }
+          limits = { "memory" : "256Mi", "cpu" : "1000m" }
         }
       }
 


### PR DESCRIPTION
This pull request includes a small change to the `google_cloud_run_service` resource in the Terraform configuration. The memory limit for the Cloud Run service has been reduced from `512Mi` to `256Mi` to optimize resource usage.